### PR TITLE
feat: Allow single spec shortcuts

### DIFF
--- a/src/components/Landing/MainForm/MainForm.tsx
+++ b/src/components/Landing/MainForm/MainForm.tsx
@@ -7,13 +7,16 @@ import {
     StackProps,
     Tooltip,
 } from "@chakra-ui/react";
+import npa from "npm-package-arg";
 import {
     FormEvent,
     FunctionComponent,
     useEffect,
+    useMemo,
     useRef,
     useState,
 } from "react";
+import TooltipCode from "^/components/theme/TooltipCode";
 import CenterInputAddon from "./CenterInputAddon";
 
 const SpecInput = forwardRef<InputProps, "input">((props, ref) => (
@@ -38,6 +41,26 @@ const MainForm: FunctionComponent<MainFormProps> = ({
     const aRef = useRef<HTMLInputElement>(null);
     const [a, setA] = useState("");
     const [b, setB] = useState("");
+
+    /**
+     * A placeholder value for `B` if nothing is entered in `B`.
+     *
+     * This will be the package of `A` with the `latest` tag.
+     */
+    const automaticB = useMemo(() => {
+        try {
+            if (b) {
+                return null;
+            }
+            const aName = npa(a)?.name;
+            if (!aName) {
+                return null;
+            }
+            return `${aName}@latest`;
+        } catch (e) {
+            return null;
+        }
+    }, [a, b]);
 
     useEffect(() => {
         // Focus the input on initial load (only)
@@ -88,7 +111,7 @@ const MainForm: FunctionComponent<MainFormProps> = ({
             >
                 <SpecInput
                     name="b"
-                    placeholder="^3.0.1 or package-b@3.X"
+                    placeholder={automaticB || undefined}
                     disabled={overrideB != null || isLoading}
                     value={overrideB ?? b ?? ""}
                     onChange={(event) => setB(event.target.value)}
@@ -97,17 +120,22 @@ const MainForm: FunctionComponent<MainFormProps> = ({
             </Tooltip>
             <Tooltip
                 label={
-                    !a || !b
-                        ? "Neither field can be emtpy"
-                        : `Compare "${a}" and "${b}" now!`
+                    !a ? (
+                        "Enter a package specification to compare"
+                    ) : (
+                        <>
+                            Compare <TooltipCode>{a}</TooltipCode> and{" "}
+                            <TooltipCode>{automaticB || b}</TooltipCode> now!
+                        </>
+                    )
                 }
-                background={!a || !b ? "red.700" : undefined}
+                background={!a ? "red.700" : undefined}
                 shouldWrapChildren
             >
                 <Button
                     isLoading={isLoading}
                     type="submit"
-                    disabled={!b || !a}
+                    disabled={!a}
                     marginInlineStart={{ lg: "2rem" }}
                 >
                     npm diff! 📦🔃

--- a/src/lib/destination/index.test.ts
+++ b/src/lib/destination/index.test.ts
@@ -11,7 +11,7 @@ interface ExpectedResults<T = string> {
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["t"] }] */
 async function t(
-    input: [string, string],
+    input: [string, string] | [string],
     expectedSpecs?: [string, string],
     expectedRedirect?: Redirect,
 ) {
@@ -166,5 +166,25 @@ describe("destination()", () => {
                     "One of the spec",
                 ));
         });
+    });
+
+    describe("provide single spec, compare with latest always", () => {
+        it("specific version", () =>
+            t(["chalk@3.0.1"], ["chalk@3.0.1", specs.latest], "temporary"));
+
+        it("specific tag", () =>
+            t(["chalk@latest"], [specs.latest, specs.latest], "temporary"));
+
+        it("semver", () =>
+            t(["chalk@^2.1"], [specs["^2.1"], specs.latest], "temporary"));
+
+        it("no version (fallback to latest)", () =>
+            t(["chalk"], [specs.latest, specs.latest], "temporary"));
+
+        it("Throws on only semver", () =>
+            expect(() => t(["^2.1"])).rejects.toThrow(/package name/i));
+
+        it("Throws on only version", () =>
+            expect(() => t(["3.0.1"])).rejects.toThrow(/package name/i));
     });
 });

--- a/src/lib/destination/index.ts
+++ b/src/lib/destination/index.ts
@@ -15,7 +15,7 @@ export interface Destination {
  * and redirect information, information if and what type of redirect we can use.
  */
 async function destination(
-    specsOrVersions: [string, string],
+    specsOrVersions: [string] | [string, string],
 ): Promise<Destination> {
     // This part is done in npm/cli
     // https://github.com/npm/cli/blob/v7.19.1/lib/diff.js#L118

--- a/src/lib/destination/versionsToSpecs.test.ts
+++ b/src/lib/destination/versionsToSpecs.test.ts
@@ -29,6 +29,28 @@ describe("versionsToSpecs", () => {
         expect(vts(specAndVersion)).toEqual(expected);
     });
 
+    it("A as spec (get B from A)", () => {
+        const specs = ["example@1.0.0"] as const;
+        const expected = ["example@1.0.0", "example@latest"] as const;
+        expect(vts(specs)).toEqual(expected);
+    });
+
+    it("A as X syntax (get B from A)", () => {
+        const specs = ["example@1.X"] as const;
+        const expected = ["example@1.X", "example@latest"] as const;
+        expect(vts(specs)).toEqual(expected);
+    });
+
+    it("Throws on single version-only input", () => {
+        const specs = ["1.0.0"] as const;
+        expect(() => vts(specs)).toThrow(/package name/i);
+    });
+
+    it("Throws on single X syntax input", () => {
+        const specs = ["1.X"] as const;
+        expect(() => vts(specs)).toThrow(/package name/i);
+    });
+
     it("Throw on two version-only inputs", () => {
         expect(() => vts(["1.0.0", "2.0.0"] as const)).toThrow();
     });

--- a/src/lib/destination/versionsToSpecs.ts
+++ b/src/lib/destination/versionsToSpecs.ts
@@ -15,8 +15,19 @@ import semver from "semver";
  *
  * > Based on: https://github.com/npm/cli/blob/v7.19.1/lib/diff.js#L235-L264
  */
-function versionsToSpecs([a, b]: readonly [string, string]): [string, string] {
+function versionsToSpecs([a, b]:
+    | readonly [string, string]
+    | readonly [string]): [string, string] {
     const semverA = semver.validRange(a);
+
+    if (!b) {
+        if (semverA) {
+            throw new Error("Missing package name");
+        }
+
+        return [a, `${npa(a).name}@latest`];
+    }
+
     const semverB = semver.validRange(b);
 
     // We cannot support both args being only versions, we need a package name

--- a/src/lib/utils/splitParts.test.ts
+++ b/src/lib/utils/splitParts.test.ts
@@ -1,0 +1,78 @@
+import exp from "constants";
+import splitParts from "./splitParts";
+
+describe("splitParts", () => {
+    it("Should fail when input is incorrect type", () => {
+        // No input
+        expect(() => splitParts()).toThrow(/Invalid query/i);
+
+        // Number input
+        expect(() =>
+            splitParts(
+                // @ts-expect-error
+                1,
+            ),
+        ).toThrow(/Invalid query/i);
+
+        // Number array input
+        expect(() =>
+            splitParts(
+                // @ts-expect-error
+                [1, 2, 3],
+            ),
+        ).toThrow(/Invalid query/i);
+
+        // Object input
+        expect(() =>
+            splitParts(
+                // @ts-expect-error
+                {},
+            ),
+        ).toThrow(/Invalid query/i);
+    });
+
+    describe("Single spec", () => {
+        it("Handles single un-scoped spec", () => {
+            expect(splitParts("package")).toEqual(["package"]);
+        });
+
+        it("Handles single scoped spec", () => {
+            expect(splitParts("@types/package")).toEqual(["@types/package"]);
+        });
+    });
+
+    describe("Two specs", () => {
+        it("Handles default usecase (two specs)", () => {
+            expect(splitParts("package@1.0.0...package@2.0.0")).toEqual([
+                "package@1.0.0",
+                "package@2.0.0",
+            ]);
+        });
+
+        it("Handles two scoped specs", () => {
+            expect(
+                splitParts("@types/package@^1...@types/package@^2".split("/")),
+            ).toEqual(["@types/package@^1", "@types/package@^2"]);
+        });
+
+        it("Handles one unscoped and one scoped", () => {
+            expect(
+                splitParts("package@^1...@types/package@^2".split("/")),
+            ).toEqual(["package@^1", "@types/package@^2"]);
+        });
+
+        it("Throws on double-scoped packages", () => {
+            expect(() =>
+                splitParts(
+                    "@types/types/package@^1...@types/package@^2".split("/"),
+                ),
+            ).toThrow(/Invalid query/i);
+        });
+    });
+
+    it("Throws on more than 2 specs", () => {
+        expect(() =>
+            splitParts("package@^1...package@^2...package@^3"),
+        ).toThrow(/Invalid query/i);
+    });
+});

--- a/src/lib/utils/splitParts.ts
+++ b/src/lib/utils/splitParts.ts
@@ -12,20 +12,32 @@ function isTupleOfTwo<T>(t: T[]): t is [T, T] {
  *
  * `['@types', 'package@^1...@types', 'package@^2']` ➡ `['@types/package@^1', '@types/package@^2']`
  */
-function splitParts(parts?: string | string[]): [string, string] {
-    if (!parts || (typeof parts !== "string" && !Array.isArray(parts))) {
-        throw new Error("Invalid query");
+function splitParts(parts?: string | string[]): [string] | [string, string] {
+    const invalidQueryError = () => new Error("Invalid query");
+
+    if (
+        !(
+            typeof parts === "string" ||
+            (Array.isArray(parts) &&
+                parts.every((p) => typeof p === "string") &&
+                // two scoped specs "@a/p@1...@a/p@2".split('/') -> ["@a", "p@1...@a", "p@2"]
+                parts.length <= 3)
+        )
+    ) {
+        throw invalidQueryError();
     }
 
     const query = typeof parts === "string" ? parts : parts.join("/");
 
     const splitted = query.split("...");
 
-    if (!isTupleOfTwo(splitted)) {
-        throw new Error("Invalid query");
+    if (splitted.length == 1) {
+        return [splitted[0]];
+    } else if (splitted.length === 2) {
+        return [splitted[0], splitted[1]];
+    } else {
+        throw invalidQueryError();
     }
-
-    return splitted;
 }
 
 export default splitParts;

--- a/src/pages/about/api.tsx
+++ b/src/pages/about/api.tsx
@@ -1,9 +1,10 @@
 import { Code, Heading, Text, Tooltip, VStack } from "@chakra-ui/react";
-import libnpmdiff from "libnpmdiff";
 import { GetStaticProps, NextPage } from "next";
 import Layout from "^/components/Layout";
 import ExternalLink from "^/components/theme/ExternalLink";
 import NextLink from "^/components/theme/NextLink";
+import destination from "^/lib/destination";
+import doDiff from "^/lib/diff";
 import EXAMPLES from "^/lib/examples";
 import splitParts from "^/lib/utils/splitParts";
 
@@ -22,10 +23,12 @@ type Props = {
 };
 
 export const getStaticProps: GetStaticProps<Props> = async ({}) => {
-    const specs = splitParts(EXAMPLE_QUERY);
-    const diff = await libnpmdiff(specs);
+    const specsOrVersions = splitParts(EXAMPLE_QUERY);
+    const { immutableSpecs } = await destination(specsOrVersions);
 
-    return { props: { diff, specs } };
+    const diff = await doDiff(immutableSpecs, {});
+
+    return { props: { diff, specs: immutableSpecs } };
 };
 
 const ApiPage: NextPage<Props> = ({ diff, specs }) => {


### PR DESCRIPTION
The idea is that if you provide only one spec, we compare it to `latest`.

Should work both for UI and API.

So you can navigate directly to https://npm-diff.app/he@1.1.1 and get redirected to https://npm-diff.app/he@1.1.1...he@latest